### PR TITLE
fix(test): remove massive change option for contact groups in host configuration page

### DIFF
--- a/src/behat/Configuration/MassiveChangeHostConfigurationPage.php
+++ b/src/behat/Configuration/MassiveChangeHostConfigurationPage.php
@@ -174,11 +174,6 @@ class MassiveChangeHostConfigurationPage extends \Centreon\Test\Behat\Configurat
             'input[name="host_notifOpts[n]"]',
             self::NOTIFICATION_TAB
         ),
-        'update_mode_hcg' => array(
-            'radio',
-            'input[name="mc_mod_hcg[mc_mod_hcg]"]',
-            self::NOTIFICATION_TAB
-        ),
         'update_mode_notif_interval' => array(
             'radio',
             'input[name="mc_mod_notifopt_notification_interval[mc_mod_notifopt_notification_interval]"]',


### PR DESCRIPTION
*master* branch.

This option was removed from the Centreon Web interface and is therefore useless.