### PR TITLE
test(monitoring): update date format check

### DIFF
--- a/src/behat/Monitoring/ServiceMonitoringDetailsPage.php
+++ b/src/behat/Monitoring/ServiceMonitoringDetailsPage.php
@@ -92,7 +92,7 @@ class ServiceMonitoringDetailsPage implements \Centreon\Test\Behat\Interfaces\Pa
 
         // last_check
         $lastCheck = $this->context->assertFindIn($table, 'css', 'tbody tr:nth-child(9) td:nth-child(2)')->getText();
-        $lastCheck = \DateTime::createFromFormat('Y/m/d - H:i:s', $lastCheck);
+        $lastCheck = new \DateTime($lastCheck);
         $result['last_check'] = ($lastCheck === false) ? false : $lastCheck->getTimestamp();
 
         // in_downtime


### PR DESCRIPTION
Update the monitoring details file which gets properties from the page. Change the way DateTime is created for the last_check property, which no longer uses the Y/m/d - H:i:s format.