### PR TITLE
Bam 538 migrate

### DIFF
--- a/src/behat/CentreonAPIContext.php
+++ b/src/behat/CentreonAPIContext.php
@@ -294,6 +294,7 @@ class CentreonAPIContext extends CentreonContext
     /**
      * @When /^I make a MULTIPART request to "([^"]*)"$/
      * @throws \Exception
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function makeMultipartRequest($uri)
     {

--- a/src/behat/CentreonAPIContext.php
+++ b/src/behat/CentreonAPIContext.php
@@ -200,6 +200,21 @@ class CentreonAPIContext extends CentreonContext
     }
 
     /**
+     * @Given /^the property "([^"]*)" has value$/
+     */
+    public function responseHasKeys($property, PyStringNode $propVal)
+    {
+        $data = json_decode($this->getResponse()->getBody(true), true);
+        if (!empty($data[$property])){
+            if ($data[$property] !== json_decode($propVal, true)){
+                throw new \Exception("Value of '".$property."' is not correct!\n");
+            }
+        } else {
+            throw new \Exception("Property '".$property."' is not found!\n");
+        }
+    }
+
+    /**
      * @Given I use request payload
      */
     public function iUseRequestPayload(PyStringNode $requestPayload)

--- a/src/behat/CentreonAPIContext.php
+++ b/src/behat/CentreonAPIContext.php
@@ -215,6 +215,21 @@ class CentreonAPIContext extends CentreonContext
     }
 
     /**
+     * @Given /^the property "([^"]*)" has value$/
+     */
+    public function responseHasKeys($property, PyStringNode $propVal)
+    {
+        $data = json_decode($this->getResponse()->getBody(true), true);
+        if (!empty($data[$property])){
+            if ($data[$property] !== json_decode($propVal, true)){
+                throw new \Exception("Value of '".$property."' is not correct!\n");
+            }
+        } else {
+            throw new \Exception("Property '".$property."' is not found!\n");
+        }
+    }
+
+    /**
      * @Given I use request payload
      */
     public function iUseRequestPayload(PyStringNode $requestPayload)

--- a/src/behat/CentreonAPIContext.php
+++ b/src/behat/CentreonAPIContext.php
@@ -282,6 +282,16 @@ class CentreonAPIContext extends CentreonContext
     }
 
     /**
+     * @When /^I make a PUT request to "([^"]*)"$/
+     */
+    public function makePutRequest($uri)
+    {
+        $jsonPayload = !empty($this->getRequestPayload()) ? ['json' => json_decode($this->getRequestPayload()->getRaw(),true)]: null;
+        $response = $this->getClient()->put($this->getMinkParameter('api_base') . $uri, $jsonPayload);
+        $this->setResponse($response);
+    }
+
+    /**
      * @When /^I make a MULTIPART request to "([^"]*)"$/
      * @throws \Exception
      */

--- a/src/mock/CentreonDB.php
+++ b/src/mock/CentreonDB.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace Centreon\Test\Mock;
 
 // \CentreonDB is not autoloaded in module unit tests, so we need to mock it
@@ -26,11 +27,12 @@ if (!class_exists("\CentreonDB")) {
  *
  * @author Centreon
  * @version 1.0.0
- * @package centreon-license-manager
+ * @package centreon-test-lib
  * @subpackage test
  */
 class CentreonDB extends \CentreonDB
 {
+
     private $queries = array();
 
     /**
@@ -42,6 +44,7 @@ class CentreonDB extends \CentreonDB
      */
     public function __construct($db = "centreon", $retry = 3, $silent = false)
     {
+
     }
 
     /**
@@ -96,14 +99,15 @@ class CentreonDB extends \CentreonDB
      * @param array $params The parameters of query, if not set :
      *   * the query has not parameters
      *   * the result is generic for the query
+     * @param callable $callback execute a callback when a query is executed
      */
-    public function addResultSet($query, $result, $params = null)
+    public function addResultSet($query, $result, $params = null, callable $callback = null)
     {
         if (!isset($this->queries[$query])) {
-            $this->queries[$query] = array();
+            $this->queries[$query] = [];
         }
-        $this->queries[$query][] = new CentreonDBResultSet($result, $params);
-        
+        $this->queries[$query][] = new CentreonDBResultSet($result, $params, $callback);
+
         return $this;
     }
 
@@ -130,22 +134,30 @@ class CentreonDB extends \CentreonDB
      */
     public function execute($query, $values = null)
     {
-        if (!isset($this->queries[$query])) {
+        if (!array_key_exists($query, $this->queries)) {
             throw new \Exception('Query is not set.' . "\nQuery : " . $query);
         }
-        /* Find good query */
+
+        // find good query
         $matching = null;
+
         foreach ($this->queries[$query] as $resultSet) {
             $result = $resultSet->match($values);
+
             if ($result === 2) {
                 return $resultSet;
-            } else if  ($result === 1 && is_null($matching)) {
+            } elseif ($result === 1 && $matching === null) {
                 $matching = $resultSet;
             }
         }
-        if (is_null($matching)) {
+
+        if ($matching === null) {
             throw new \Exception('Query is not set.' . "\nQuery : " . $query);
         }
+
+        // trigger callback
+        $matching->executeCallback($values);
+
         return $matching;
     }
 
@@ -176,5 +188,4 @@ class CentreonDB extends \CentreonDB
     {
         return;
     }
-
 }

--- a/src/mock/CentreonDBAdapter.php
+++ b/src/mock/CentreonDBAdapter.php
@@ -59,6 +59,20 @@ class CentreonDBAdapter extends BaseCentreonDBAdapter
         return $this;
     }
 
+    public function setCommitCallback(callable $callback = null): CentreonDBAdapter
+    {
+        $this->getCentreonDBInstance()->setCommitCallback($callback);
+
+        return $this;
+    }
+
+    public function setLastInsertId(int $id = null)
+    {
+        $this->getCentreonDBInstance()->setLastInsertId($id);
+
+        return $this;
+    }
+
     public function addRepositoryMock(string $className, object $repository): CentreonDBAdapter
     {
         $this->mocks[$className] = $repository;

--- a/src/mock/CentreonDBAdapter.php
+++ b/src/mock/CentreonDBAdapter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace Centreon\Test\Mock;
 
 use Centreon\Infrastructure\CentreonLegacyDB\CentreonDBAdapter as BaseCentreonDBAdapter;
+use Centreon\Infrastructure\CentreonLegacyDB\ServiceEntityRepository;
 
 /**
  * Mock class for dbconn
  *
  * @author Centreon
  * @version 1.0.0
- * @package centreon-license-manager
+ * @package centreon-test-lib
  * @subpackage test
  */
 class CentreonDBAdapter extends BaseCentreonDBAdapter
 {
 
-    public function addResultSet($query, $result, $params = null)
+    /**
+     * @var array
+     */
+    protected $mocks = [];
+
+    public function getRepository($repository): ServiceEntityRepository
     {
-        return $this->getCentreonDBInstance()->addResultSet($query, $result, $params);
+        if (array_key_exists($repository, $this->mocks)) {
+            return $this->mocks[$repository];
+        }
+
+        return parent::getRepository($repository);
+    }
+
+    public function resetResultSet(): CentreonDBAdapter
+    {
+        $this->getCentreonDBInstance()->resetResultSet();
+
+        return $this;
+    }
+
+    public function addResultSet($query, $result, $params = null, callable $callback = null): CentreonDBAdapter
+    {
+        $this->getCentreonDBInstance()->addResultSet($query, $result, $params, $callback);
+
+        return $this;
+    }
+
+    public function addRepositoryMock(string $className, object $repository): CentreonDBAdapter
+    {
+        $this->mocks[$className] = $repository;
+
+        return $this;
     }
 }

--- a/src/mock/CentreonDBAdapter.php
+++ b/src/mock/CentreonDBAdapter.php
@@ -54,6 +54,11 @@ class CentreonDBAdapter extends BaseCentreonDBAdapter
         return $this;
     }
 
+    public function getMocks(): array
+    {
+        return $this->mocks;
+    }
+
     public function addResultSet($query, $result, $params = null, callable $callback = null): CentreonDBAdapter
     {
         $this->getCentreonDBInstance()->addResultSet($query, $result, $params, $callback);

--- a/src/mock/CentreonDBAdapter.php
+++ b/src/mock/CentreonDBAdapter.php
@@ -47,6 +47,8 @@ class CentreonDBAdapter extends BaseCentreonDBAdapter
 
     public function resetResultSet(): CentreonDBAdapter
     {
+        $this->mocks = [];
+
         $this->getCentreonDBInstance()->resetResultSet();
 
         return $this;

--- a/src/mock/CentreonDBManagerService.php
+++ b/src/mock/CentreonDBManagerService.php
@@ -35,7 +35,7 @@ class CentreonDBManagerService extends BaseCentreonDBManagerService
 {
 
     /**
-     * @var \Centreon\Test\Mock\CentreonDBAdapter 
+     * @var \Centreon\Test\Mock\CentreonDBAdapter
      */
     protected $manager;
 
@@ -45,6 +45,11 @@ class CentreonDBManagerService extends BaseCentreonDBManagerService
     }
 
     public function getAdapter(string $alias): BaseCentreonDBAdapter
+    {
+        return $this->manager;
+    }
+
+    public function getDefaultAdapter(): BaseCentreonDBAdapter
     {
         return $this->manager;
     }
@@ -66,8 +71,20 @@ class CentreonDBManagerService extends BaseCentreonDBManagerService
         return $this->manager->addResultSet($query, $result, $params, $callback);
     }
 
+    public function setCommitCallback(callable $callback = null)
+    {
+        return $this->manager->setCommitCallback($callback);
+    }
+
     public function addRepositoryMock(string $className, object $repository)
     {
         return $this->manager->addRepositoryMock($className, $repository);
+    }
+
+    public function setLastInsertId(int $id = null)
+    {
+        $this->manager->setLastInsertId($id);
+
+        return $this;
     }
 }

--- a/src/mock/CentreonDBManagerService.php
+++ b/src/mock/CentreonDBManagerService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace Centreon\Test\Mock;
 
 use Centreon\Infrastructure\Service\CentreonDBManagerService as BaseCentreonDBManagerService;
+use Centreon\Infrastructure\CentreonLegacyDB\CentreonDBAdapter as BaseCentreonDBAdapter;
 use Centreon\Infrastructure\CentreonLegacyDB\ServiceEntityRepository;
 use Centreon\Test\Mock\CentreonDB;
 use Centreon\Test\Mock\CentreonDBAdapter;
@@ -26,7 +28,7 @@ use Centreon\Test\Mock\CentreonDBAdapter;
  *
  * @author Centreon
  * @version 1.0.0
- * @package centreon-license-manager
+ * @package centreon-test-lib
  * @subpackage test
  */
 class CentreonDBManagerService extends BaseCentreonDBManagerService
@@ -42,7 +44,7 @@ class CentreonDBManagerService extends BaseCentreonDBManagerService
         $this->manager = new CentreonDBAdapter(new CentreonDB);
     }
 
-    public function getAdapter(string $alias) : \Centreon\Infrastructure\CentreonLegacyDB\CentreonDBAdapter
+    public function getAdapter(string $alias): BaseCentreonDBAdapter
     {
         return $this->manager;
     }
@@ -54,8 +56,18 @@ class CentreonDBManagerService extends BaseCentreonDBManagerService
         return $manager;
     }
 
-    public function addResultSet($query, $result, $params = null)
+    public function resetResultSet()
     {
-        return $this->manager->addResultSet($query, $result, $params);
+        return $this->manager->resetResultSet();
+    }
+
+    public function addResultSet($query, $result, $params = null, callable $callback = null)
+    {
+        return $this->manager->addResultSet($query, $result, $params, $callback);
+    }
+
+    public function addRepositoryMock(string $className, object $repository)
+    {
+        return $this->manager->addRepositoryMock($className, $repository);
     }
 }

--- a/src/mock/CentreonDBResultSet.php
+++ b/src/mock/CentreonDBResultSet.php
@@ -27,7 +27,6 @@ namespace Centreon\Test\Mock;
  */
 class CentreonDBResultSet
 {
-
     protected $resultset = [];
     protected $params = null;
     protected $pos = 0;

--- a/src/mock/CentreonDBResultSet.php
+++ b/src/mock/CentreonDBResultSet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace Centreon\Test\Mock;
 
 /**
@@ -21,14 +22,20 @@ namespace Centreon\Test\Mock;
  *
  * @author Centreon
  * @version 1.0.0
- * @package centreon-license-manager
+ * @package centreon-test-lib
  * @subpackage test
  */
 class CentreonDBResultSet
 {
-    private $resultset = array();
-    private $params = null;
-    private $pos = 0;
+
+    protected $resultset = [];
+    protected $params = null;
+    protected $pos = 0;
+
+    /**
+     * @var callable
+     */
+    protected $callback;
 
     /**
      * Constructor
@@ -37,13 +44,26 @@ class CentreonDBResultSet
      * @param array $params The parameters of query, if not set :
      *   * the query has not parameters
      *   * the result is generic for the query
+     * @param callable $callback execute a callback when a query is executed
      */
-    public function __construct($resultset, $params = null)
+    public function __construct($resultset, $params = null, callable $callback = null)
     {
         $this->resultset = $resultset;
         $this->params = $params;
-        if (!is_null($this->params)) {
+        $this->callback = $callback;
+
+        if ($this->params !== null) {
             ksort($this->params);
+        }
+    }
+
+    /**
+     * Execute the callback comes from the test case object
+     */
+    public function executeCallback($values = null)
+    {
+        if ($this->callback !== null) {
+            call_user_func($this->callback, $values);
         }
     }
 
@@ -99,8 +119,10 @@ class CentreonDBResultSet
         return $this->rowCount();
     }
 
-    /*
+    /**
      * Count of updated lines
+     *
+     * @return int
      */
     public function rowCount()
     {
@@ -118,24 +140,17 @@ class CentreonDBResultSet
      */
     public function match($params = null)
     {
-        if (is_null($params) && is_null($this->params)) {
-            return 2;
-        }
-        if (is_null($this->params)) {
-            return 1;
-        }
-        if (!is_null($params)) {
-            ksort($params);
-        }
         if ($this->params === $params) {
             return 2;
+        } elseif ($this->params === null) {
+            return 1;
+        } elseif ($params !== null) {
+            ksort($params);
         }
+
         return 0;
     }
 
-    /**
-     *
-     */
     public function closeCursor()
     {
         return;

--- a/src/mock/CentreonDBResultSet.php
+++ b/src/mock/CentreonDBResultSet.php
@@ -109,6 +109,14 @@ class CentreonDBResultSet
     }
 
     /**
+     * Get resultset stack
+     */
+    public function getResultSet(): array
+    {
+        return $this->resultset;
+    }
+
+    /**
      * Return the number of rows of the result set
      *
      * @return int


### PR DESCRIPTION
extend CentreonDB mock with:
 - options to reset dataset
 - deep test with callbacks when the query is executed
 - ability to test transactions
 - improve rowCount to return real results
 - extend mock with new mocked methods

Resolve BAM-538 and BAM-540