### PR TITLE
Improve the ContifurationPage::setProperties to properly handling with old checkboxes and radio buttons

### DIFF
--- a/src/behat/ConfigurationPage.php
+++ b/src/behat/ConfigurationPage.php
@@ -133,6 +133,11 @@ abstract class ConfigurationPage extends Page implements Interfaces\Configuratio
                 case 'radio':
                     $radio = $this->context->assertFind('css', $propertyLocator . '[value="' . $value . '"]');
                     try {
+                        // if the parent is td tag then doesn't throw exception
+                        if (!in_array($radio->getParent()->getTagName(), ['div', 'span'])) {
+                            throw new \Exception('Parent of the radio button is not div');
+                        }
+
                         $radio->getParent()->click(); // material design radio
                     } catch (\Exception $e) {
                         $radio->click(); // native radio

--- a/src/behat/ConfigurationPage.php
+++ b/src/behat/ConfigurationPage.php
@@ -117,6 +117,11 @@ abstract class ConfigurationPage extends Page implements Interfaces\Configuratio
                     $checkboxValue = $checkbox->getValue();
                     if (($value && !$checkboxValue) || (!$value && $checkboxValue)) {
                         try {
+                            // if the parent is td tag then doesn't throw exception
+                            if (!in_array($checkbox->getParent()->getTagName(), ['div', 'span'])) {
+                                throw new \Exception('Parent of the checkbox is not div');
+                            }
+
                             $checkbox->getParent()->click(); // material design checkbox
                         } catch (\Exception $e) {
                             $checkbox->click(); // native checkbox


### PR DESCRIPTION
there is a problem with checkboxes and radio buttons in 19.04.x because the parent is "td" element and somehow doesn't throw an exception on click event

Resolve BAM-806