### PR TITLE
enh(test): avoid useless switchToIframe calls

### DIFF
--- a/src/behat/Configuration/HostTemplateConfigurationListingPage.php
+++ b/src/behat/Configuration/HostTemplateConfigurationListingPage.php
@@ -64,8 +64,6 @@ class HostTemplateConfigurationListingPage extends \Centreon\Test\Behat\ListingP
         $this->context = $context;
         if ($visit) {
             $this->context->visit('main.php?p=60103');
-        } else {
-            $this->context->switchToIframe();
         }
 
         // Check that page is valid for this class.

--- a/src/behat/Configuration/HostTemplateConfigurationPage.php
+++ b/src/behat/Configuration/HostTemplateConfigurationPage.php
@@ -352,8 +352,6 @@ class HostTemplateConfigurationPage extends \Centreon\Test\Behat\ConfigurationPa
         $this->context = $context;
         if ($visit) {
             $this->context->visit('main.php?p=60103&o=a');
-        } else {
-            $this->context->switchToIframe();
         }
 
         // Check that page is valid for this class.


### PR DESCRIPTION
The calls were made on host creation witch tried to switchToIframe even when already on iFrame. 60 sec were lost everytime due to the spin