### PR TITLE
feat(api): allow to store result section in variable

### DIFF
--- a/src/behat/Api/Context/ApiContext.php
+++ b/src/behat/Api/Context/ApiContext.php
@@ -199,6 +199,34 @@ class ApiContext implements Context
     }
 
     /**
+     * Store custom variables
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    protected function addCustomVariable(string $name, $value)
+    {
+        $this->customVariables[$name] = $value;
+    }
+
+    /**
+     * Get custom variable by name
+     *
+     * @param string $name
+     * @return mixed
+     * @throws \Exception
+     */
+    protected function getCustomVariable(string $name)
+    {
+        if (!isset($this->customVariables[$name])) {
+            throw new \Exception('Variable "' . $name . '" is not stored');
+        }
+
+        return $this->customVariables[$name];
+    }
+
+    /**
      *  Set containers Compose files.
      */
     public function setContainersComposeFiles($files)

--- a/src/behat/Api/Context/JsonContextTrait.php
+++ b/src/behat/Api/Context/JsonContextTrait.php
@@ -48,6 +48,13 @@ Trait JsonContextTrait
     abstract protected function setHttpResponse(ResponseInterface $httpResponse);
 
     /**
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    abstract protected function addCustomVariable(string $name, $value);
+
+    /**
      * @return JsonInspector
      */
     private function getInspector()
@@ -500,5 +507,21 @@ Trait JsonContextTrait
             ['$ref' => 'file://' . $fullPath],
             \JsonSchema\Constraints\Constraint::CHECK_MODE_EXCEPTIONS
         );
+    }
+
+    /**
+     * Store custom variables
+     *
+     * @Given I store response values in:
+     */
+    public function iStoreResponseValuesIn(TableNode $table)
+    {
+        $json = $this->getJson();
+
+        foreach ($table as $row) {
+            $value = $this->getInspector()->evaluate($json, $row['path']);
+
+            $this->addCustomVariable($row['name'], $value);
+        }
     }
 }


### PR DESCRIPTION
**Usage :** 
```
    Given I send a GET request to '/beta/monitoring/hosts
    And I store response values in:
      | name   | path         |
      | hostId | result[0].id |
    When I send a GET request to '/beta/monitoring/hosts/<hostId>/timeline'
```