### PR TITLE
fix(acceptance): fix random fails on login page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "behat/mink": "Browser controller/emulator abstraction for PHP",
         "behat/mink-selenium2-driver": "Mink driver using Selenium"
     },
-    "license": "Apache-2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Maximilien Bersoult",

--- a/src/behat/CentreonContext.php
+++ b/src/behat/CentreonContext.php
@@ -785,7 +785,14 @@ class CentreonContext extends UtilsContext
         }
 
         // Login.
-        $page = new LoginPage($this);
-        $page->login($user, $password);
+        $this->spin(
+            function ($context) use ($user, $password) {
+                $page = new LoginPage($context);
+                $page->login($user, $password);
+                return true;
+            },
+            'cannot login',
+            3
+        );
     }
 }


### PR DESCRIPTION
Sometimes, acceptance tests fails randomly on login page.
It seems to be related to centreon token, which is not initialized.
Don't want to waste more time on 2.8, so I set a spin on login..