### PR TITLE
fix(ApiContext): use correct endpoint for authentication

### DIFF
--- a/src/behat/Api/Context/ApiContext.php
+++ b/src/behat/Api/Context/ApiContext.php
@@ -507,7 +507,7 @@ class ApiContext implements Context
         $this->setHttpHeaders(['Content-Type' => 'application/json']);
         $this->iSendARequestToWithBody(
             'POST',
-            $baseUriWithoutApi . '/authentication/providers/local',
+            $baseUriWithoutApi . '/authentication/providers/configurations/local',
             json_encode([
                 'login' => 'admin',
                 'password' => 'centreon',


### PR DESCRIPTION
Fix local authentication endpoint using the correct one /authentication/providers/configurations/local