### PR TITLE
enh(platform): remove centreon web path option

### DIFF
--- a/src/behat/Administration/ParametersCentreonUiPage.php
+++ b/src/behat/Administration/ParametersCentreonUiPage.php
@@ -27,10 +27,6 @@ class ParametersCentreonUiPage extends \Centreon\Test\Behat\ConfigurationPage
             'input',
             'input[name="oreon_path"]'
         ),
-        'web_directory' => array(
-            'input',
-            'input[name="oreon_web_path"]'
-        ),
         'web_base_root' => array(
             'input',
             'input[name="centreon_web_base_root"]'


### PR DESCRIPTION
## Description

remove centreon web path option

**Fixes** MON-12893

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)