### PR TITLE
fix(tests): Fixing Metrics acceptance tests 21.04.x

### DIFF
--- a/src/behat/Monitoring/MetricsConfigurationPage.php
+++ b/src/behat/Monitoring/MetricsConfigurationPage.php
@@ -35,7 +35,7 @@ class MetricsConfigurationPage extends \Centreon\Test\Behat\ConfigurationPage
             'select[name="def_type"]'
         ),
         'known_metrics' => array(
-            'select',
+            'select2',
             'select#sl_list_metrics'
         ),
         'function' => array(


### PR DESCRIPTION
## Description

Since we changed the "select" by select2 of the "list of metrics" in Monitoring > Performances > Virtual Metrics, they made a regression in some of acceptance tests, this PR should take care of it.

**Fixes** # MON-14359

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
