### PR TITLE
fix(phpstan) implement a particular case in exception custom rule 

### DIFF
--- a/src/PHPStan/CustomRules/ArchitectureRules/ExceptionInUseCaseCustomRule.php
+++ b/src/PHPStan/CustomRules/ArchitectureRules/ExceptionInUseCaseCustomRule.php
@@ -58,7 +58,6 @@ class ExceptionInUseCaseCustomRule implements Rule
         if (
             ! $this->fileInUseCase($scope->getFile())
             || $this->getParentClassMethod($node)->name->name === '__construct'
-            // temporarily excluded private methods from checking
             || $this->getParentClassMethod($node)->isPrivate() === true
         ) {
             return [];

--- a/src/PHPStan/CustomRules/ArchitectureRules/ExceptionInUseCaseCustomRule.php
+++ b/src/PHPStan/CustomRules/ArchitectureRules/ExceptionInUseCaseCustomRule.php
@@ -64,8 +64,8 @@ class ExceptionInUseCaseCustomRule implements Rule
             return [];
         }
 
-        // get string representation of Exception class
-        $exceptionThrown = $node->expr->class->toCodeString();
+        // check if Exception class is not null and get string representation of Exception class
+        $exceptionThrown = $node->expr->class !== null ? $node->expr->class->toCodeString() : '';
         $parentTryCatchNodes = $this->getAllParentTryCatchNodes($node);
         $caughtExceptionTypes = $this->getCaughtExceptionTypes($parentTryCatchNodes);
 

--- a/src/PHPStan/CustomRules/RepositoryRules/RepositoryMethodReturnCustomRule.php
+++ b/src/PHPStan/CustomRules/RepositoryRules/RepositoryMethodReturnCustomRule.php
@@ -73,20 +73,21 @@ class RepositoryMethodReturnCustomRule implements Rule
      */
     private function getErrorsForReturnTypeInFindMethod(ClassMethod $classMethod): array
     {
+        $returnType = $classMethod->getReturnType();
         if (
             preg_match('/^find/', $classMethod->name->name)
             && ! (
                 (
-                    $classMethod->getReturnType() instanceof NullableType &&
+                    $returnType instanceof NullableType &&
                     (
                         // $classMethod->getReturnType()->type->toString() get a string of a class name (i.e. "Host")
                         // in case of a nullable object return statement in method signature.
-                        class_exists($classMethod->getReturnType()->type->toString())
-                        || interface_exists($classMethod->getReturnType()->type->toString())
+                        class_exists($returnType->type->toString())
+                        || interface_exists($returnType->type->toString())
                     )
                 )
-                || $classMethod->getReturnType()->toString() === 'array'
-                || $classMethod->getReturnType()->toString() === 'iterable'
+                || ($returnType instanceof NullableType ? '' : $returnType->toString()) === 'array'
+                || ($returnType instanceof NullableType ? '' : $returnType->toString()) === 'iterable'
             )
         ) {
             return [
@@ -108,16 +109,17 @@ class RepositoryMethodReturnCustomRule implements Rule
      */
     private function getErrorsForReturnTypeInGetMethod(ClassMethod $classMethod): array
     {
+        $returnType = $classMethod->getReturnType();
         if (
             preg_match('/^get/', $classMethod->name->name) &&
             ! (
                 (
                     // $classMethod->getReturnType()->toString() get a string of a class name (i.e. "Host")
                     // in case of a non-nullable object return statement in method signature.
-                    class_exists($classMethod->getReturnType()->toString())
-                    || interface_exists($classMethod->getReturnType()->toString())
+                    class_exists($returnType instanceof NullableType ? '' : $returnType->toString())
+                    || interface_exists($returnType instanceof NullableType ? '' : $returnType->toString())
                 )
-                || $classMethod->getReturnType()->toString() === 'array'
+                || ($returnType instanceof NullableType ? '' : $returnType->toString()) === 'array'
             )
         ) {
             return [


### PR DESCRIPTION
## Description

This PR adapts PHPStan Exception Custom rule to exclude constructor methods from checking.
It contains :
- implementation of additional checks to exclude constructor methods
- implementation of unit tests for constrauctor methos case

**Fixes** # MON-14778

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
