### PR TITLE
feat(behat): Add a Context to be able to use a user under ACL in tests

### DIFF
--- a/src/behat/Api/Context/ApiContext.php
+++ b/src/behat/Api/Context/ApiContext.php
@@ -712,7 +712,7 @@ class ApiContext implements Context
     /**
      * @Given I am logged in with :username\/:password
      */
-    public function iAmLoggedInWith($username, $password)
+    public function iAmLoggedInWith(string $username, string $password)
     {
         $this->setHttpHeaders(['Content-Type' => 'application/json']);
         $response = $this->iSendARequestToWithBody(

--- a/src/behat/Api/Context/ApiContext.php
+++ b/src/behat/Api/Context/ApiContext.php
@@ -708,4 +708,27 @@ class ApiContext implements Context
             1
         );
     }
+
+    /**
+     * @Given I am logged in with :username\/:password
+     */
+    public function iAmLoggedInWith($username, $password)
+    {
+        $this->setHttpHeaders(['Content-Type' => 'application/json']);
+        $response = $this->iSendARequestToWithBody(
+            'POST',
+            $this->getBaseUri() . '/api/latest/login',
+            json_encode([
+                'security' => [
+                    'credentials' => [
+                        'login' => $username,
+                        'password' => $password,
+                    ],
+                ],
+            ])
+        );
+
+        $response = json_decode($response->getBody()->__toString(), true);
+        $this->setToken($response['security']['token']);
+    }
 }


### PR DESCRIPTION
## Description

Added the method to be able to use a non-admin user in tests.

**Fixes** # MON-15254

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

How To Test

Test 1:

- In a .feature  file (e.g LocalProviderConfiguration) use a CLAPI Import to create user that doesnt have access to api configuration
- Use the context I am Logged In With :username/:password
- The endpoints should not be accessible

Test 2:

- In a .feature  file (e.g LocalProviderConfiguration) use a CLAPI Import to create user that has access to api configuration
- Use the context I am Logged In With :username/:password
- The endpoints should be accessible

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
