### PR TITLE
replace macros for JSON is equal to

### DIFF
--- a/src/behat/Api/Context/ApiContext.php
+++ b/src/behat/Api/Context/ApiContext.php
@@ -257,6 +257,23 @@ class ApiContext implements Context
     }
 
     /**
+     * Replace custom variables
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function replaceCustomVariables(string $value): string
+    {
+        if (preg_match_all('/<([\w\d]+)>/', $value, $matches)) {
+            foreach ($matches[1] as $match) {
+                $value = str_replace('<' . $match . '>', $this->getCustomVariable($match), $value);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
      *  Set containers Compose files.
      */
     public function setContainersComposeFiles($files)

--- a/src/behat/Api/Context/JsonContextTrait.php
+++ b/src/behat/Api/Context/JsonContextTrait.php
@@ -412,7 +412,7 @@ Trait JsonContextTrait
         $actual = $this->getJson();
 
         try {
-            $expected = new Json((string) $this->replaceCustomVariables($content));
+            $expected = new Json($this->replaceCustomVariables($content));
         } catch (\Exception $e) {
             throw new \Exception('The expected JSON is not a valid');
         }

--- a/src/behat/Api/Context/JsonContextTrait.php
+++ b/src/behat/Api/Context/JsonContextTrait.php
@@ -55,6 +55,14 @@ Trait JsonContextTrait
     abstract protected function addCustomVariable(string $name, $value);
 
     /**
+     * Replace custom variables
+     *
+     * @param string $value
+     * @return string
+     */
+    abstract protected function replaceCustomVariables(string $value): string;
+
+    /**
      * @return JsonInspector
      */
     private function getInspector()
@@ -404,7 +412,7 @@ Trait JsonContextTrait
         $actual = $this->getJson();
 
         try {
-            $expected = new Json($content);
+            $expected = new Json((string) $this->replaceCustomVariables($content));
         } catch (\Exception $e) {
             throw new \Exception('The expected JSON is not a valid');
         }

--- a/src/behat/Api/Context/RestContextTrait.php
+++ b/src/behat/Api/Context/RestContextTrait.php
@@ -87,11 +87,12 @@ Trait RestContextTrait
     abstract protected function getBaseUri();
 
     /**
-     * @param string $name
-     * @return mixed
-     * @throws \Exception
+     * Replace custom variables
+     *
+     * @param string $value
+     * @return string
      */
-    abstract protected function getCustomVariable(string $name);
+    abstract protected function replaceCustomVariables(string $value): string;
 
     /**
      * Parse URI path
@@ -253,23 +254,6 @@ Trait RestContextTrait
             $this->locatePath($url),
             $parameters
         );
-    }
-
-    /**
-     * Replace custom variables
-     *
-     * @param string $value
-     * @return string
-     */
-    private function replaceCustomVariables(string $value): string
-    {
-        if (preg_match_all('/<([\w\d]+)>/', $value, $matches)) {
-            foreach ($matches[1] as $match) {
-                $value = str_replace('<' . $match . '>', $this->getCustomVariable($match), $value);
-            }
-        }
-
-        return $value;
     }
 
     /**


### PR DESCRIPTION
This PR intends to add the possibility to replace macros set from previous API call in the method "JSON is equal to:"

Example

```
[........]
    And I send a GET request to '/api/v23.04/monitoring/services?search={"$and":[{"host.name":"test"},{"service.description":"test_service_1"}]}'
    And I store response values in:
      | name      | path              |
      | hostId    | result[0].host.id |
      | serviceId | result[0].id      |

    When I send a GET request to '/api/latest/bam/configuration/indicators?search={"name": {"$lk": "%test_service_1%"}}'
    Then the response code should be "200"
    And the JSON should be equal to:
    """
    {
        "result": [
            {
                "uuid": "h<hostId>-s<serviceId>",
                "name": "test - test_service_1",
                "type": "service",
                "short_type": "s",
                "resource": {
                    "id": <serviceId>,
                    "parent_id": <hostId>
                },
                "enabled": true
            }
        ],
        "meta": {
            "page": 1,
            "limit": 10,
            "search": {
                "$and": {
                    "name": {
                        "$lk": "%test_service_1%"
                    }
                }
            },
            "sort_by": {},
            "total": 1
        }
    }
    """

```

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
