### PR TITLE
fix(api integration): add a step to wait for broker bulk execution

### DIFF
--- a/src/behat/Api/Context/RestContextTrait.php
+++ b/src/behat/Api/Context/RestContextTrait.php
@@ -504,4 +504,12 @@ Trait RestContextTrait
             . $this->getHttpResponse()->getBody()->__toString();
         Assert::eq($expectedCode, $actualCode, $message);
     }
+
+    /**
+     * @Given I Wait until broker bulk is done
+     */
+    public function iWaitUntilBrokerBulkIsDone()
+    {
+        sleep(10);
+    }
 }


### PR DESCRIPTION
## Description

This PR intends to add a step in context to wait for broker bulk execution. This could be useful to avoid errors on reading centreon_storage.resources table during tests execution.

The waiting time has been set to 10 seconds according to feedbacks of collect teams

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
