### PR TITLE
fix(engine): wait centreon engine is totally reloaded

### DIFF
--- a/src/behat/CentreonContext.php
+++ b/src/behat/CentreonContext.php
@@ -702,7 +702,7 @@ class CentreonContext extends UtilsContext
      */
     private function getEngineReloadCount(): int
     {
-        $getEngineLogsCommand = 'cat /var/log/centreon-engine/centengine.log | grep "Configuration reloaded" | wc -l';
+        $getEngineLogsCommand = 'grep "Configuration reloaded" /var/log/centreon-engine/centengine.log | wc -l';
 
         $output = $this->container->execute(
             $getEngineLogsCommand,

--- a/src/behat/CentreonContext.php
+++ b/src/behat/CentreonContext.php
@@ -703,13 +703,12 @@ class CentreonContext extends UtilsContext
     private function getEngineReloadCount(): int
     {
         $getEngineLogsCommand = 'cat /var/log/centreon-engine/centengine.log | grep "Configuration reloaded" | wc -l';
+
         $output = $this->container->execute(
             $getEngineLogsCommand,
             $this->webService,
-            false
+            true
         );
-
-        var_dump('count of reload : ' . (int) $output['output']);
 
         return (int) $output['output'];
     }


### PR DESCRIPTION
## Description

fix(engine): wait centreon engine is totally reloaded by checking "Configuration reloaded" in centreon-engine logs

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)