### PR TITLE
fix(test): make select2 selection resilient

### DIFF
--- a/src/behat/Home/CustomViewsPage.php
+++ b/src/behat/Home/CustomViewsPage.php
@@ -58,7 +58,7 @@ class CustomViewsPage extends \Centreon\Test\Behat\Page
     {
         $this->context->spin(
             function ($context) use ($show) {
-                $context->toggleEditBar($show);
+                $this->toggleEditBar($show);
                 $barVisible = $context->assertFind('css', 'button.addView')->isVisible();
                 return $show == $barVisible;
             },

--- a/src/behat/Home/CustomViewsPage.php
+++ b/src/behat/Home/CustomViewsPage.php
@@ -56,9 +56,9 @@ class CustomViewsPage extends \Centreon\Test\Behat\Page
      */
     public function showEditBar($show = true)
     {
-        $this->toggleEditBar($show);
         $this->context->spin(
             function ($context) use ($show) {
+                $context->toggleEditBar($show);
                 $barVisible = $context->assertFind('css', 'button.addView')->isVisible();
                 return $show == $barVisible;
             },

--- a/src/behat/UtilsContext.php
+++ b/src/behat/UtilsContext.php
@@ -428,7 +428,7 @@ class UtilsContext extends RawMinkContext
                             $('{$cssId}').trigger('change');
                             */
                             $('.select2-results__option > div[title="{$what}"]').trigger('mouseup');
-                            $('{$cssId}').select2('close');
+                            //$('{$cssId}').select2('close');
                         })();
                     JS
                 );

--- a/src/behat/UtilsContext.php
+++ b/src/behat/UtilsContext.php
@@ -360,6 +360,7 @@ class UtilsContext extends RawMinkContext
         $this->getSession()->evaluateScript(
             <<<JS
                 (function() {
+                    $('{$cssId}').select2('close');
                     //$('{$cssId}').select2('open');
 
                     // Get the search box within the dropdown or the selection
@@ -397,6 +398,24 @@ class UtilsContext extends RawMinkContext
 
         $this->spin(
             function ($context) use ($what, $cssId) {
+                if (
+                    $context->getSession()->getPage()->has(
+                        'css',
+                        'span.select2-results '
+                        . 'li.select2-results__option:not(.loading-results):not(.select2-results__message)'
+                        . '[aria-selected="true"] > div[title="' . $what . '"]'
+                    )
+                ) {
+                    $this->getSession()->evaluateScript(
+                        <<<JS
+                            (function() {
+                                $('{$cssId}').select2('close');
+                            })();
+                        JS
+                    );
+
+                    return true;
+                }
                 //$select2Span = $context->assertFind('css', 'span.select2-results');
                 $option = $context->assertFind(
                     'css',

--- a/src/behat/UtilsContext.php
+++ b/src/behat/UtilsContext.php
@@ -415,7 +415,6 @@ class UtilsContext extends RawMinkContext
                     5,
                 );
 
-                var_dump(
                 $context->getSession()->evaluateScript(
                     <<<JS
                         (function() {
@@ -432,7 +431,6 @@ class UtilsContext extends RawMinkContext
                             $('{$cssId}').select2('close');
                         })();
                     JS
-                )
                 );
 
                 //$option->click();

--- a/src/behat/UtilsContext.php
+++ b/src/behat/UtilsContext.php
@@ -409,7 +409,7 @@ class UtilsContext extends RawMinkContext
 
                 $context->spin(
                     function ($context) {
-                        $context->getSession()->getPage()->has('css', 'li.select2-results__option--highlighted');
+                        return $context->getSession()->getPage()->has('css', 'li.select2-results__option--highlighted');
                     },
                     'select2 option ' . $what . ' is not focused',
                     5,

--- a/src/behat/UtilsContext.php
+++ b/src/behat/UtilsContext.php
@@ -403,7 +403,7 @@ class UtilsContext extends RawMinkContext
                 $context->getSession()->evaluateScript(
                     <<<JS
                         (function() {
-                            $('{$cssId}').select2('close');
+                            //$('{$cssId}').select2('close');
                             //$('{$cssId}').select2('open');
 
                             // Get the search box within the dropdown or the selection

--- a/src/behat/UtilsContext.php
+++ b/src/behat/UtilsContext.php
@@ -357,6 +357,26 @@ class UtilsContext extends RawMinkContext
      */
     public function selectToSelectTwo($cssId, $what)
     {
+        $this->getSession()->evaluateScript(
+            <<<JS
+                (function() {
+                    //$('{$cssId}').select2('open');
+
+                    // Get the search box within the dropdown or the selection
+                    // Dropdown = single, Selection = multiple
+                    let \$search = $('{$cssId}').data('select2').dropdown.\$search || $('{$cssId}').data('select2').selection.\$search;
+                    // This is undocumented and may change in the future
+
+                    \$search.val('{$what}');
+                    \$search.trigger('input');
+
+                    //$('{$cssId}').val(['{$what}']);
+                    //$('{$cssId}').trigger('change');
+                })();
+            JS
+        );
+
+        /*
         // Open select2.
         $this->assertFind('css', $cssId)->getParent()->find('css', 'span.select2-selection')->click();
 
@@ -371,14 +391,57 @@ class UtilsContext extends RawMinkContext
         $this->getSession()->evaluateScript(
             'jQuery(".select2-container--open .select2-search__field").val(`' . $what . '`).trigger("keyup")'
         );
+        */
+
+        //sleep(3);
 
         $this->spin(
             function ($context) use ($what, $cssId) {
-                $chosenResults = [];
-                $select2Span = $context->assertFind('css', 'span.select2-results');
+                //$select2Span = $context->assertFind('css', 'span.select2-results');
+                $option = $context->assertFind(
+                    'css',
+                    'span.select2-results '
+                    . 'li.select2-results__option:not(.loading-results):not(.select2-results__message)'
+                    . '[aria-selected="false"] > div[title="' . $what . '"]'
+                );
+
+                $option->focus();
+
+                $context->spin(
+                    function ($context) {
+                        $context->getSession()->getPage()->has('css', 'li.select2-results__option--highlighted');
+                    },
+                    'select2 option ' . $what . ' is not focused',
+                    5,
+                );
+
+                var_dump(
+                $context->getSession()->evaluateScript(
+                    <<<JS
+                        (function() {
+                            /*
+                            let e = $.Event("keypress");
+                            e.which = 13;
+                            e.keyCode = 13;
+                            $('li.select2-results__option--highlighted > div').focus();
+                            //$('li.select2-results__option--highlighted > div').trigger(e);
+                            $('li.select2-results__option--highlighted > div').click();
+                            $('{$cssId}').trigger('change');
+                            */
+                            $('.select2-results__option > div[title="{$what}"]').trigger('mouseup');
+                            $('{$cssId}').select2('close');
+                        })();
+                    JS
+                )
+                );
+
+                //$option->click();
+
+                return true;
+                /*
                 $chosenResults = $select2Span->findAll(
                     'css',
-                    'li.select2-results__option:not(.loading-results):not(.select2-results__message)'
+                    'li.select2-results__option:not(.loading-results):not(.select2-results__message)[aria-selected="false"] > div[title="' . $what . '"]'
                 );
                 if (count($chosenResults) === 0) {
                     return false;
@@ -391,9 +454,18 @@ class UtilsContext extends RawMinkContext
                     }
                 }
                 return false;
+                */
             },
             'Cannot find results in select2 ' . $cssId,
             10
+        );
+
+        $this->spin(
+            function ($context) use ($cssId) {
+                return $context->assertFind('css', $cssId)->getParent()
+                    ->has('css', '.select2-container--open') === false;
+            },
+            'select2 ' . $cssId . ' is not closed'
         );
     }
 


### PR DESCRIPTION
## Description

fix(test): make select2 selection resilient : 
* use jquery to search and select
* add assertions for focus, highlight, selection and closing

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)