### PR TITLE
fix(api/behat) tests on headers

### DIFF
--- a/src/behat/Api/Context/RestContextTrait.php
+++ b/src/behat/Api/Context/RestContextTrait.php
@@ -301,10 +301,12 @@ Trait RestContextTrait
     {
         $this->theHeaderShouldExist($name);
 
+        $value = $this->replaceCustomVariables($value);
+
         /**
          * @var string
          */
-        $actual = $this->getHttpResponse()->getHeader($name);
+        $actual = $this->getHttpResponse()->getHeader($name)[0];
 
         Assert::eq(
             strtolower($value),
@@ -321,10 +323,12 @@ Trait RestContextTrait
     public function theHeaderShouldNotBeEqualTo($name, $value) {
         $this->theHeaderShouldExist($name);
 
+        $value = $this->replaceCustomVariables($value);
+
         /**
          * @var string
          */
-        $actual = $this->getHttpResponse()->getHeader($name);
+        $actual = $this->getHttpResponse()->getHeader($name)[0];
 
         Assert::notEq(
             strtolower($value),


### PR DESCRIPTION
## Description

fix theHeaderShouldBeEqualTo() and theHeaderShouldNotBeEqualTo() methods in RestContextTrait for Behat testing
(getHeader return an array of string and not a string)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)
