### PR TITLE
fix(api): reload acl on debian with www-data user

### DIFF
--- a/src/behat/Api/Context/ApiContext.php
+++ b/src/behat/Api/Context/ApiContext.php
@@ -683,7 +683,7 @@ class ApiContext implements Context
      * @param int $tries Count of tries
      * @return int the count of results
      *
-     * @Given /^I wait to get (\d+) results? from "(\S+)"(?: \(tries: (\d+)\))?$/
+     * @Given /^I wait to get (\d+) results? from ['"](\S+)['"](?: \(tries: (\d+)\))?$/
      */
     public function iWaitToGetSomeResultsFrom(int $count, string $url, int $tries = 15): int
     {

--- a/src/behat/Api/Context/CentreonClapiContextTrait.php
+++ b/src/behat/Api/Context/CentreonClapiContextTrait.php
@@ -64,11 +64,21 @@ Trait CentreonClapiContextTrait
             $this->webService
         );
 
-        //Reload ACL
+        $this->reloadAcl();
+    }
+
+    /**
+     * Reload resources acl
+     */
+    private function reloadAcl(): void
+    {
+        $apacheUserCommand = 'getent passwd www-data 2>&1 > /dev/null && echo "www-data" || echo "apache"';
+        $reloadAclCommand = 'su -s /bin/sh $APACHE_USER -c "/usr/bin/env php -q /usr/share/centreon/cron/centAcl.php"';
+
+        // Reload ACL
         $this->container->execute(
-            'su -s /bin/sh apache -c "/usr/bin/env php -q /usr/share/centreon/cron/centAcl.php"',
-            $this->webService,
-            false
+            "bash -c 'APACHE_USER=$($apacheUserCommand) $reloadAclCommand'",
+            $this->webService
         );
     }
 }


### PR DESCRIPTION
## Description

reload acl on debian with www-data user

**Fixes** MON-20805

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)