### PR TITLE
fix(api): avoid sprintf format error when asserting a json with %

### DIFF
--- a/src/behat/Api/Context/JsonContextTrait.php
+++ b/src/behat/Api/Context/JsonContextTrait.php
@@ -430,7 +430,7 @@ Trait JsonContextTrait
         Assert::same(
             (string) $expected,
             (string) $actual,
-            "The json is equal to:\n". $actual->encode()
+            "The json is equal to:\n" . str_replace('%', '%%', $actual->encode())
         );
     }
 


### PR DESCRIPTION
## Description

fix(api): avoid sprintf format error when asserting a json with %

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software