### PR TITLE
fix(test): add retry mechanism to docker compose start and stop

### DIFF
--- a/src/behat/Container.php
+++ b/src/behat/Container.php
@@ -17,11 +17,15 @@
  */
 namespace Centreon\Test\Behat;
 
+use Centreon\Test\Behat\SpinTrait;
+
 /**
  *  Run a container and manage it.
  */
 class Container
 {
+    use SpinTrait;
+
     private $composeFile;
     private $id;
     private $host = null;
@@ -50,15 +54,23 @@ class Container
             )
             . ' -p ' . $this->id . ' up -d --quiet-pull';
 
-        passthru($command, $returnVar);
+        $this->spin(
+            function ($context) use ($command) {
+                passthru($command, $returnVar);
 
-        if ($returnVar !== 0) {
-            throw new \Exception(
-                'Cannot execute container control command: '
-                . $command. " \n "
-                . ' (code ' . $returnVar . ')'
-            );
-        }
+                if ($returnVar !== 0) {
+                    throw new \Exception(
+                        'Cannot execute container control command: '
+                        . $command. " \n "
+                        . ' (code ' . $returnVar . ')'
+                    );
+                }
+
+                return true;
+            },
+            'Cannot start docker containers',
+            30
+        );
 
         $this->initContainersInfos();
     }
@@ -115,8 +127,19 @@ class Container
      */
     public function __destruct()
     {
-        $this->exec('docker-compose -f ' . $this->composeFile . ' -p ' . $this->id . ' kill');
-        $this->exec('docker-compose -f ' . $this->composeFile . ' -p ' . $this->id . ' down -v');
+        try {
+            $this->spin(
+                function ($context) {
+                    $context->exec('docker-compose -f ' . $this->composeFile . ' -p ' . $this->id . ' kill');
+                    $context->exec('docker-compose -f ' . $this->composeFile . ' -p ' . $this->id . ' down -v');
+                    return true;
+                },
+                'Cannot stop docker containers',
+                30
+            );
+        } catch (\Throwable $e) {
+            echo 'Exception: ' . $e->getMessage();
+        }
     }
 
     /**

--- a/src/behat/SpinTrait.php
+++ b/src/behat/SpinTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Copyright 2016-2023 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Centreon\Test\Behat;
+
+use Centreon\Test\Behat\Exception\SpinStopException;
+
+trait SpinTrait
+{
+    /**
+     * Waiting an action
+     *
+     * @param \Closure $closure The function to execute for test the loading.
+     * @param string $timeoutMsg The custom message on timeout.
+     * @param int $wait The timeout in seconds.
+     * @return bool
+     * @throws \Exception
+     */
+    public function spin(\Closure $closure, string $timeoutMsg = 'Load timeout', int $wait = 60)
+    {
+        $limit = time() + $wait;
+        $lastException = null;
+        while (time() <= $limit) {
+            try {
+                if ($closure($this)) {
+                    return true;
+                }
+            } catch (SpinStopException $e) {
+                // stop spining
+                throw $e;
+            } catch (\Throwable $e) {
+                $lastException = $e;
+            }
+            \usleep(100_000);
+        }
+        if (is_null($lastException)) {
+            throw new \Exception($timeoutMsg);
+        } else {
+            throw new \Exception(
+                $timeoutMsg . ': ' . $lastException->getMessage() . ' (code ' .
+                $lastException->getCode() . ', file ' . $lastException->getFile() .
+                ':' . $lastException->getLine() . ')'
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description

add retry mechanism to docker compose start and stop

cherry-picked from https://github.com/centreon/centreon-test-lib/commit/62a3517742929f37706c24839ab3ed1332287b4e

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)