### PR TITLE
fix (php-cs-fixer): removal date verification in PHP file headers

### DIFF
--- a/src/PhpCsFixer/PhpCsFixerRuleSet.php
+++ b/src/PhpCsFixer/PhpCsFixerRuleSet.php
@@ -178,17 +178,6 @@ class PhpCsFixerRuleSet
             'whitespace_after_comma_in_array' => true,
         ];
 
-        // Set the header dynamically based on the current detected project name.
-        $projectLicense = PhpCsFixerLicense::detectCentreonProjectLicense(__DIR__);
-        if ($phpLicenseHeader = PhpCsFixerLicense::getLicenseHeaderAsText($projectLicense)) {
-            $rules += [
-                'header_comment' => [
-                    'location' => 'after_open',
-                    'header' => $phpLicenseHeader,
-                ],
-            ];
-        }
-
         return $rules;
     }
 


### PR DESCRIPTION
## Description

Removal of the php-cs-fixer rule concerning date verification in PHP file headers

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
