### PR TITLE
fix(panther): remove Chrome broken flag following update to chrome 128

### DIFF
--- a/src/behat/CentreonContext.php
+++ b/src/behat/CentreonContext.php
@@ -126,7 +126,7 @@ class CentreonContext extends UtilsContext
             $driver = new PantherDriver($defaultOptions, $kernelOptions, $managerOptions);
             $driver->start();
         } catch (\Exception $e) {
-            throw new \Exception("Cannot instantiate panther driver : " . $e->getTraceAsString(), (int) $e->getCode(), $e);
+            throw new \Exception("Cannot instantiate panther driver : " . $e->getMessage(), (int) $e->getCode(), $e);
         }
 
         try {

--- a/src/behat/CentreonContext.php
+++ b/src/behat/CentreonContext.php
@@ -33,6 +33,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Mink\Mink;
 use Behat\Mink\Session;
 use Behat\Mink\Driver\PantherDriver;
+use Symfony\Component\Panther\PantherTestCase;
 
 class CentreonContext extends UtilsContext
 {
@@ -85,7 +86,6 @@ class CentreonContext extends UtilsContext
                 '--no-experiments',
                 '--no-first-run',
                 '--no-initial-navigation',
-                '--no-startup-window',
                 '--no-wifi',
                 '--suppress-message-center-popups',
                 '--disable-extensions',
@@ -107,7 +107,7 @@ class CentreonContext extends UtilsContext
             $defaultOptions = [
                 'external_base_uri' => 'http://' . $this->container->getHost() . ':'
                     . $this->container->getPort(80, $this->webService),
-                'browser' => 'chrome',
+                'browser' => PantherTestCase::CHROME,
             ];
 
             $kernelOptions = []; # unused cause we do not extend class KernelTestCase
@@ -126,7 +126,7 @@ class CentreonContext extends UtilsContext
             $driver = new PantherDriver($defaultOptions, $kernelOptions, $managerOptions);
             $driver->start();
         } catch (\Exception $e) {
-            throw new \Exception("Cannot instantiate panther driver : " . $e->getMessage(), (int) $e->getCode(), $e);
+            throw new \Exception("Cannot instantiate panther driver : " . $e->getTraceAsString(), (int) $e->getCode(), $e);
         }
 
         try {


### PR DESCRIPTION
## Description

This PR intends to remove Chrome broken flag following update to chrome 128. This flag is used by Panther when the Behat tests are executed

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
