### PR TITLE
fix(Method): Method signature doesn't match

### DIFF
--- a/src/mock/CentreonDB.php
+++ b/src/mock/CentreonDB.php
@@ -201,7 +201,7 @@ class CentreonDB extends \CentreonDB
      * @param type $enable
      * @return type
      */
-    public function autoCommit($enable)
+    public function autoCommit($enable): void
     {
         return;
     }


### PR DESCRIPTION
## Description

Fixed the issue where method signature mismatch breaks unit tests in https://github.com/centreon/centreon-modules/pull/3849

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
