### PR TITLE
fix(rule): missing comma in possible exception names array

### DIFF
--- a/src/PHPStan/CustomRules/MiscRules/VariableLengthCustomRule.php
+++ b/src/PHPStan/CustomRules/MiscRules/VariableLengthCustomRule.php
@@ -43,7 +43,7 @@ class VariableLengthCustomRule implements Rule
         'db',
         'ex',
         'id',
-        'e'
+        'e',
         'th',
     ];
 


### PR DESCRIPTION
Missing comma causes issue with phpstan excecution