### PR TITLE
fix(ci): handle unix socket based runner config for docker daemon (#265)

### DIFF
--- a/src/behat/Container.php
+++ b/src/behat/Container.php
@@ -279,7 +279,10 @@ class Container
     {
         if ($this->host === null) {
             $docker = getenv('DOCKER_HOST');
+            // Handle both TCP docker listenner or UNIX socket docker listenner
             if (!preg_match('@^(tcp://)?([^:]+)@', $docker, $matches)) {
+                $retval = '127.0.0.1';
+            } elseif (preg_match('@^(unix:///)?([^:]+)@', $docker, $matches)) {
                 $retval = '127.0.0.1';
             } else {
                 $retval = $matches[2];


### PR DESCRIPTION
fix(ci): handle unix socket based runner config

## Description

- due to recent changes in runner configuration, docker daemon only listens on unix socket and not tcp
- added a condition specific to unix socket docker_host

Fixes #MON-163849

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
