### PR TITLE
fix(Behat): Changed assetion type on Image Listing Page for media folder synchronisation

### DIFF
--- a/src/behat/Administration/ImageListingPage.php
+++ b/src/behat/Administration/ImageListingPage.php
@@ -87,7 +87,7 @@ class ImageListingPage extends \Centreon\Test\Behat\ListingPage
      */
     public function synchronize(): void
     {
-        $this->context->assertFindLink('Synchronize Media Directory')->click();
+        $this->context->assertFindButton('Synchronize Media Directory')->click();
     }
 
     /**


### PR DESCRIPTION
## Description

Changed assetion type on Image Listing Page for media folder synchronisation

**Fixes** # MON-167547-ACL-medias

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
